### PR TITLE
Subjects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 node_modules
+secrets.ts

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest run",
     "test:dev": "vitest",
     "ci": "pnpm run lint && pnpm run test && pnpm run build",
-    "release": "pnpm run ci && changeset publish"
+    "release": "pnpm run ci && changeset publish",
+    "dev:watch": "tsup src/index.ts --format cjs,esm --dts --watch"
   },
   "keywords": [],
   "author": "",
@@ -24,8 +25,8 @@
     "vitest": "^0.34.4"
   },
   "dependencies": {
-    "@thinknimble/tn-models": "2.1.0",
+    "@thinknimble/tn-models": "2.1.1",
     "axios": "1.5.0",
-    "zod": "3.22.2"
+    "zod": "3.21.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,5 +22,10 @@
     "tsup": "^7.2.0",
     "typescript": "^5.2.2",
     "vitest": "^0.34.4"
+  },
+  "dependencies": {
+    "@thinknimble/tn-models": "2.1.0",
+    "axios": "1.5.0",
+    "zod": "3.22.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,5 +1,16 @@
 lockfileVersion: '6.0'
 
+dependencies:
+  '@thinknimble/tn-models':
+    specifier: 2.1.0
+    version: 2.1.0(axios@1.5.0)(zod@3.22.2)
+  axios:
+    specifier: 1.5.0
+    version: 1.5.0
+  zod:
+    specifier: 3.22.2
+    version: 3.22.2
+
 devDependencies:
   '@changesets/cli':
     specifier: ^2.26.2
@@ -512,6 +523,23 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
+  /@thinknimble/tn-models@2.1.0(axios@1.5.0)(zod@3.22.2):
+    resolution: {integrity: sha512-r0YCiNfyidwSfcPQUgE2JcuH1c4EkFsPzfGRwdAjqy6nV5Hkq2aoMGsDW9m6xiVN99wFxHnWPyFiUNT3GP1A9w==}
+    peerDependencies:
+      axios: '>1.0.0'
+      zod: '>=3.21.4'
+    dependencies:
+      '@thinknimble/tn-utils': 2.0.1
+      axios: 1.5.0
+      zod: 3.22.2
+    dev: false
+
+  /@thinknimble/tn-utils@2.0.1:
+    resolution: {integrity: sha512-9P8iKkep7eqgkyoA819vyKFHAq/C8GtV0QGCfu32CYCSFsA+1DOV4+bqtIdlcVa2dhIyEZz7JZ6GCffXk+f7gw==}
+    dependencies:
+      type-fest: 3.13.1
+    dev: false
+
   /@types/chai-subset@1.3.3:
     resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
@@ -688,10 +716,24 @@ packages:
     resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
+  /asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: false
+
   /available-typed-arrays@1.0.5:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
+
+  /axios@1.5.0:
+    resolution: {integrity: sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==}
+    dependencies:
+      follow-redirects: 1.15.2
+      form-data: 4.0.0
+      proxy-from-env: 1.1.0
+    transitivePeerDependencies:
+      - debug
+    dev: false
 
   /balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -866,6 +908,13 @@ packages:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
     dev: true
 
+  /combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: false
+
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -969,6 +1018,11 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: true
+
+  /delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: false
 
   /detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -1195,11 +1249,30 @@ packages:
       pkg-dir: 4.2.0
     dev: true
 
+  /follow-redirects@1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dev: false
+
   /for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
     dependencies:
       is-callable: 1.2.7
     dev: true
+
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -1756,6 +1829,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+    dev: false
+
+  /mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+    dependencies:
+      mime-db: 1.52.0
+    dev: false
+
   /mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -2057,6 +2142,10 @@ packages:
       ansi-styles: 5.2.0
       react-is: 18.2.0
     dev: true
+
+  /proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+    dev: false
 
   /pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
@@ -2577,6 +2666,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /type-fest@3.13.1:
+    resolution: {integrity: sha512-tLq3bSNx+xSpwvAJnzrK0Ep5CLNWjvFTOp71URMaAEWBfRb9nnJiBoUe0tF8bI4ZFO3omgBR6NvnbzVUT3Ly4g==}
+    engines: {node: '>=14.16'}
+    dev: false
+
   /typed-array-buffer@1.0.0:
     resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
     engines: {node: '>= 0.4'}
@@ -2940,3 +3034,7 @@ packages:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}
     engines: {node: '>=12.20'}
     dev: true
+
+  /zod@3.22.2:
+    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
+    dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,14 +2,14 @@ lockfileVersion: '6.0'
 
 dependencies:
   '@thinknimble/tn-models':
-    specifier: 2.1.0
-    version: 2.1.0(axios@1.5.0)(zod@3.22.2)
+    specifier: 2.1.1
+    version: 2.1.1(axios@1.5.0)(zod@3.21.4)
   axios:
     specifier: 1.5.0
     version: 1.5.0
   zod:
-    specifier: 3.22.2
-    version: 3.22.2
+    specifier: 3.21.4
+    version: 3.21.4
 
 devDependencies:
   '@changesets/cli':
@@ -523,15 +523,15 @@ packages:
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
     dev: true
 
-  /@thinknimble/tn-models@2.1.0(axios@1.5.0)(zod@3.22.2):
-    resolution: {integrity: sha512-r0YCiNfyidwSfcPQUgE2JcuH1c4EkFsPzfGRwdAjqy6nV5Hkq2aoMGsDW9m6xiVN99wFxHnWPyFiUNT3GP1A9w==}
+  /@thinknimble/tn-models@2.1.1(axios@1.5.0)(zod@3.21.4):
+    resolution: {integrity: sha512-6k6Bi3ln5Y7JRfPa14N1FPuhb7ypPjiP+IwpZtuja8vD8BkqBVL4cRT+VeQ8FSV/RdKcLqZ/VH4GFzvqEWgy7w==}
     peerDependencies:
       axios: '>1.0.0'
       zod: '>=3.21.4'
     dependencies:
       '@thinknimble/tn-utils': 2.0.1
       axios: 1.5.0
-      zod: 3.22.2
+      zod: 3.21.4
     dev: false
 
   /@thinknimble/tn-utils@2.0.1:
@@ -3035,6 +3035,6 @@ packages:
     engines: {node: '>=12.20'}
     dev: true
 
-  /zod@3.22.2:
-    resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
+  /zod@3.21.4:
+    resolution: {integrity: sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==}
     dev: false

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-console.log("Hello world");
+export * from "./services";

--- a/src/services/axios-client.ts
+++ b/src/services/axios-client.ts
@@ -1,0 +1,22 @@
+import axios from "axios";
+const WANIKANI_URL = "https://api.wanikani.com/v2";
+
+let token = "";
+export const client = axios.create({
+  baseURL: WANIKANI_URL,
+});
+
+export const updateWnkToken = (newToken: string) => {
+  token = newToken;
+};
+
+client.interceptors.request.use(
+  (config) => {
+    config.headers["Content-Type"] = `application/x-www-form-urlencoded`;
+    config.headers["Authorization"] = `Bearer ${token}`;
+    return config;
+  },
+  (err) => {
+    Promise.reject(err);
+  }
+);

--- a/src/services/common/collections.ts
+++ b/src/services/common/collections.ts
@@ -1,0 +1,15 @@
+import z from "zod";
+import { objectTypes } from "./object-types";
+
+export const getBaseModelCollection = <T extends z.ZodRawShape>(shape: T) => ({
+  object: z.literal(objectTypes.collection),
+  url: z.string().url(),
+  pages: z.object({
+    nextUrl: z.string().nullable(),
+    previousUrl: z.string().nullable(),
+    perPage: z.number(),
+  }),
+  totalCount: z.number(),
+  dataUpdatedAt: z.string().datetime().nullable(),
+  data: z.object(shape).array(),
+});

--- a/src/services/common/index.ts
+++ b/src/services/common/index.ts
@@ -1,0 +1,1 @@
+export * from "./models";

--- a/src/services/common/kanji.ts
+++ b/src/services/common/kanji.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { readingShape } from "./reading";
+
+const kanjiReadingType = {
+  on: "onyomi",
+  kun: "kunyomi",
+  nano: "nanori",
+};
+
+const kanjiReadingShape = z.object(readingShape).merge(
+  z.object({
+    type: z.nativeEnum(kanjiReadingType),
+  })
+).shape;
+
+export const kanjiShape = {
+  amalgamationSubjectIds: z.number().array(),
+  componentSubjectIds: z.number().array(),
+  meaningHint: z.string().nullable(),
+  readingHint: z.string().nullable(),
+  readingMnemonic: z.string(),
+  readings: z.object(kanjiReadingShape).array(),
+  visuallySimilarSubjectIds: z.number().array(),
+};

--- a/src/services/common/models.ts
+++ b/src/services/common/models.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { kanjiShape } from "./kanji";
+import { ObjectTypes, objectTypes } from "./object-types";
+import { radicalShape } from "./radical";
+import { kanaVocabularyShape, vocabularyShape } from "./vocabulary";
+
+const dataShapeByObjectType: Record<ObjectTypes, z.ZodRawShape> = {
+  kanji: kanjiShape,
+  kana_vocabulary: kanaVocabularyShape,
+  vocabulary: vocabularyShape,
+  radical: radicalShape,
+  collection: { tbd: z.unknown() },
+};
+
+export const getBaseModelShape = <T extends z.ZodRawShape>(
+  innerShape: T
+  // type: ObjectTypes
+) => {
+  // const resolvedShape = dataShapeByObjectType[type];
+  return {
+    // object: z.literal(type),
+    object: z.nativeEnum(objectTypes),
+    url: z.string().url(),
+    dataUpdatedAt: z.string().datetime().nullable(),
+    //TODO: we might just want to determine inner shape from the `objectTypes` rather than from user parameter so it is something to take into account.
+    // data: z.object(resolvedShape),
+    data: z.object(innerShape),
+  };
+};

--- a/src/services/common/object-types.ts
+++ b/src/services/common/object-types.ts
@@ -1,0 +1,21 @@
+//! we could try to do some magic with this to determine the different possible types of data. But might get quite complicated
+export const objectTypes = {
+  radical: "radical",
+  kanji: "kanji",
+  vocabulary: "vocabulary",
+  kanaVocabulary: "kana_vocabulary",
+  collection: "collection",
+  // report: "report",
+  // assignment: "assignment",
+  // levelProgression: "level_progression",
+  // reset: "reset",
+  // reviewStatistic: "review_statistic",
+  // review: "review",
+  // spacedRepetitionSystem: "spaced_repetition_system",
+  // studyMaterial: "study_material",
+  // user: "user",
+  // voiceActor: "voice_actor",
+} as const;
+
+type ObjectTypesEnum = typeof objectTypes;
+export type ObjectTypes = ObjectTypesEnum[keyof ObjectTypesEnum];

--- a/src/services/common/radical.ts
+++ b/src/services/common/radical.ts
@@ -1,0 +1,27 @@
+import z from "zod";
+
+const contentTypes = {
+  png: "image/png",
+  svg: "image/svg+xml",
+};
+
+const pngContentShape = {
+  color: z.string(),
+  dimensions: z.string(),
+  styleName: z.string(),
+};
+const svgContentShape = {
+  inlineStyles: z.boolean(),
+};
+
+const imageShape = {
+  url: z.string().url(),
+  contentType: z.nativeEnum(contentTypes),
+  metadata: z.object(pngContentShape).or(z.object(svgContentShape)),
+};
+
+export const radicalShape = {
+  amalgamationSubjectIds: z.number().array(),
+  characters: z.string().nullable(),
+  characterImages: z.object(imageShape).array(),
+};

--- a/src/services/common/reading.ts
+++ b/src/services/common/reading.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const readingShape = {
+  reading: z.string(),
+  primary: z.boolean(),
+  acceptedAnswer: z.boolean(),
+};

--- a/src/services/common/vocabulary.ts
+++ b/src/services/common/vocabulary.ts
@@ -1,0 +1,41 @@
+import z from "zod";
+import { readingShape } from "./reading";
+
+const contextSentenceShape = {
+  en: z.string(),
+  ja: z.string(),
+};
+
+const pronunciationAudioMetadataAttributeShape = {
+  gender: z.string(),
+  sourceId: z.number(),
+  pronunciation: z.string(),
+  voiceActorId: z.number(),
+  voiceActorName: z.string(),
+  voiceDescription: z.string(),
+};
+const pronunciationAudioShape = {
+  url: z.string().url(),
+  contentType: z.nativeEnum({
+    mpeg: "audio/mpeg",
+    ogg: "audio/ogg",
+  }),
+  metadata: z.object(pronunciationAudioMetadataAttributeShape),
+};
+
+export const vocabularyShape = {
+  componentSubjectIds: z.number().array(),
+  contextSentences: z.object(contextSentenceShape).array(),
+  meaningMnemonic: z.string(),
+  partsOfSpeech: z.string().array(),
+  pronunciationAudios: z.object(pronunciationAudioShape).array(),
+  readings: z.object(readingShape).array(),
+  readingMnemonic: z.string(),
+};
+
+export const kanaVocabularyShape = {
+  contextSentences: z.object(contextSentenceShape).array(),
+  meaningMnemonic: z.string(),
+  partsOfSpeech: z.string().array(),
+  pronunciationAudios: z.object(pronunciationAudioShape).array(),
+};

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,2 @@
+export { subjectApi as subjects } from "./subjects";
+export { updateWnkToken } from "./axios-client";

--- a/src/services/subjects/api.test.ts
+++ b/src/services/subjects/api.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { updateWnkToken } from "../axios-client";
+import { wnkToken } from "../../../secrets";
+import { subjectApi } from "./api";
+
+//TODO: remove these thoughts put them somewhere else
+// for the time being we should just hit the api and there shouldn't be many tests set up. if we actually were to check the health status of the sdk vs the api (see if anything has changed ig) we probably would want to do a run on the endpoints bt we should be careful of the rate limit so we shoulnd't run too many tests for that..
+
+describe("Subjects", () => {
+  it("tests subject api", async () => {
+    updateWnkToken(wnkToken);
+    const result = await subjectApi.csc.getAll({
+      filters: {
+        types: ["kanji"],
+        levels: [5],
+      },
+    });
+    console.log(result);
+  });
+});

--- a/src/services/subjects/api.ts
+++ b/src/services/subjects/api.ts
@@ -1,0 +1,42 @@
+import { createApi, createCustomServiceCall } from "@thinknimble/tn-models";
+import z from "zod";
+import { client } from "../axios-client";
+import { getBaseModelShape } from "../common";
+import { getBaseModelCollection } from "../common/collections";
+import { subjectShape } from "./models";
+
+const wnkCustomFilterParser = (filters: object) => {
+  //@ts-expect-error not sure why this doesn't work really...
+  return new URLSearchParams(filters).toString();
+};
+
+const getAll = createCustomServiceCall(
+  {
+    outputShape: getBaseModelCollection(getBaseModelShape(subjectShape)),
+    filtersShape: {
+      ids: z.number().array(),
+      types: z.string().array(),
+      slugs: z.string().array(),
+      levels: z.number().array(),
+    },
+  },
+  async ({ utils, client, slashEndingBaseUri, parsedFilters }) => {
+    const urlParams = parsedFilters
+      ? "?" + wnkCustomFilterParser(parsedFilters)
+      : "";
+    //@ts-expect-error we didnt' yet fix the slash ending thing
+    const res = await client.get(`${slashEndingBaseUri}${urlParams}`);
+    return utils.fromApi(res.data);
+  }
+);
+
+export const subjectApi = createApi(
+  {
+    baseUri: "subjects",
+    disableTrailingSlash: true,
+    client,
+  },
+  {
+    getAll,
+  }
+);

--- a/src/services/subjects/index.ts
+++ b/src/services/subjects/index.ts
@@ -1,0 +1,1 @@
+export * from "./api";

--- a/src/services/subjects/models.ts
+++ b/src/services/subjects/models.ts
@@ -1,0 +1,26 @@
+import z from "zod";
+
+const meaningShape = {
+  meaning: z.string(),
+  primary: z.boolean(),
+  acceptedAnswer: z.boolean(),
+};
+
+const auxiliaryMeaningShape = {
+  meaning: z.string(),
+  type: z.enum(["whitelist", "blacklist"]),
+};
+
+export const subjectShape = {
+  auxiliaryMeanings: z.object(auxiliaryMeaningShape).array(),
+  characters: z.string(),
+  createdAt: z.string().datetime(),
+  documentUrl: z.string().url(),
+  hiddenAt: z.string().datetime().nullable(),
+  lessonPosition: z.number(),
+  level: z.number(),
+  meaningMnemonic: z.string(),
+  meanings: z.object(meaningShape).array(),
+  slug: z.string(),
+  spacedRepetitionSystemId: z.number(),
+};


### PR DESCRIPTION
# What this does
- add subjects `getAll`

# How it is used on a client
```typescript
      subjects.csc.getAll({
        filters: {
          levels: [5, 4],
          types: ["kanji"],
        },
      }),
```
# Checklist
- [ ] Improve surface api so that users don't care about `csc` and stuff within tn-models
- [ ] Improve the `types` filter value, we should be able to hint the user of the possible types they can choose from.