### PR TITLE
docs(readme): add badges and stability/roadmap notes

### DIFF
--- a/.changeset/readme-badges-and-stability.md
+++ b/.changeset/readme-badges-and-stability.md
@@ -1,0 +1,5 @@
+---
+"wanikani-sdk": minor
+---
+
+Documentation: add npm version / CI / license badges at the top of the README, a pre-1.0 stability callout setting consumer expectations, and an explicit Roadmap section documenting deferred items (SRS-mutating writes, per-resource `If-Modified-Since` arguments, built-in caching). No API changes.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # wanikani-sdk
 
+[![npm version](https://img.shields.io/npm/v/wanikani-sdk.svg)](https://www.npmjs.com/package/wanikani-sdk)
+[![CI](https://github.com/lakardion/wanikani-sdk/actions/workflows/main.yml/badge.svg)](https://github.com/lakardion/wanikani-sdk/actions/workflows/main.yml)
+[![license](https://img.shields.io/npm/l/wanikani-sdk.svg)](./LICENSE)
+
 Typed, runtime-validated TypeScript SDK for the [WaniKani v2 API](https://docs.api.wanikani.com/20170710/).
 
 Schemas are defined with [valibot](https://valibot.dev) and serve as the single source of truth for both compile-time types and runtime validation of inputs and outputs. Includes a built-in 60 req/min rate limiter and a strict one-retry policy on transient failures to keep API keys out of trouble.
+
+> **Status:** API is pre-1.0; minor versions may introduce breaking changes until 1.0.0.
 
 ## Install
 
@@ -82,7 +88,13 @@ Every resource hangs off a configured `WanikaniClient` instance.
 | [`spacedRepetitionSystems`](#spacedrepetitionsystems) | `.get(id)`, `.list(...)`, `.paginate(...)` | —                                  |
 | [`voiceActors`](#voiceactors)                         | `.get(id)`, `.list(...)`, `.paginate(...)` | —                                  |
 
-SRS-mutating writes (`POST /reviews`, `PUT /assignments/:id/start`) are intentionally not exposed yet to avoid accidentally advancing review state on real accounts.
+### Roadmap
+
+Known deferrals — these will land in later 0.x releases:
+
+- `POST /reviews` (submit a review) and `PUT /assignments/:id/start` — intentionally not exposed yet to avoid accidentally advancing SRS state on real accounts.
+- Per-resource `If-Modified-Since` / `If-None-Match` arguments. Today the transport supports conditional requests end-to-end but the resource methods don't yet take the headers as a parameter; see [Conditional requests](#conditional-requests).
+- A built-in caching layer on top of the conditional-request plumbing.
 
 ### `user`
 


### PR DESCRIPTION
## Summary

Documentation-only release. Three additions to `README.md`:

- **Badge row** under the H1: npm version, CI status, license.
- **Pre-1.0 stability callout** between the description and Install section so consumers know minor versions may break until 1.0.
- **Roadmap section** replacing the single deferred-SRS-writes sentence with an explicit list of known deferrals (`POST /reviews`, `PUT /assignments/:id/start`, per-resource `If-Modified-Since` wiring, caching).

Includes a Changesets entry marking this as a **minor** bump (per the user's intent to exercise the minor flow). The actual change is docs-only — no API impact.

## Why a PR for docs?

This is the canonical changesets/action flow documented in `CLAUDE.md`. Merging this PR triggers `publish.yml`, which will open a follow-up **Version Packages** PR bumping `package.json` to `0.2.0` + regenerating `CHANGELOG.md`. Merging that second PR triggers the actual `npm publish`.

## Test plan

- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun test` (unchanged from `main`)
- [ ] CI on this PR is green
- [ ] After merge: confirm a "Version Packages" PR opens automatically
- [ ] After merging that PR: confirm `wanikani-sdk@0.2.0` appears on npm and `v0.2.0` tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)